### PR TITLE
Don't use safe navigation operator on unexpected nils

### DIFF
--- a/ruby/ampersand-and-nils.md
+++ b/ruby/ampersand-and-nils.md
@@ -1,0 +1,27 @@
+# Don't use safe navigation operator unless `nil` is expected
+
+Don't use the safe navigation ("lonely") operator to paper over an unexpected `nil`. This is _not_ the root cause of the bug and while doing so may suppress it, it's only going to make things harder to understand.
+
+The safe navigation operator _is_ appropriate, however, when the receiver could _legitimately_ be `nil`.
+
+## Bad
+
+````ruby
+foo.bar # => raises NoMethodError. "OH NO! better do this..."
+````
+
+````diff
+-foo.bar
++foo&.bar
+````
+
+## Good
+
+````ruby
+foo.bar if foo.present? # => "hmm this is a little redundant, let's do this..."
+````
+
+````diff
+-foo.bar if foo.present?
++foo&.bar
+````


### PR DESCRIPTION
proposes a new rule saying we shouldn't use the safe navigation operator (`&.`) unless the receiver could legitimately be `nil`

(if anyone has a better example to add for this particular rule, I'm all ears)