### PR TITLE
Add Rubocop config

### DIFF
--- a/ruby/.rubocop.yml
+++ b/ruby/.rubocop.yml
@@ -1,0 +1,336 @@
+AllCops:
+  TargetRubyVersion: 2.6.2
+  Exclude:
+    - db/schema.rb
+    - bin/**/*
+    - client/**/*
+    - public/**/*
+    - script/**/*
+    - vendor/**/*
+    - node_modules/**/*
+
+AccessorMethodName:
+  Enabled: false
+
+ActionFilter:
+  Enabled: true
+  EnforcedStyle: action
+
+Alias:
+  Enabled: false
+
+ArrayJoin:
+  Enabled: false
+
+AsciiComments:
+  Enabled: false
+
+AsciiIdentifiers:
+  Enabled: false
+
+Attr:
+  Enabled: false
+
+BlockNesting:
+  Enabled: false
+
+Bundler/OrderedGems:
+  Enabled: false
+
+CaseEquality:
+  Enabled: false
+
+CharacterLiteral:
+  Enabled: false
+
+ClassAndModuleChildren:
+  Enabled: false
+
+ClassLength:
+  Enabled: false
+
+ClassVars:
+  Enabled: false
+
+# CollectionMethods:
+#   PreferredMethods:
+#     find: detect
+#     reduce: inject
+#     collect: map
+#     find_all: select
+
+ColonMethodCall:
+  Enabled: false
+
+CommentAnnotation:
+  Enabled: false
+
+CyclomaticComplexity:
+  Enabled: false
+
+Delegate:
+  Enabled: false
+
+PreferredHashMethods:
+  Enabled: false
+
+Documentation:
+  Enabled: false
+
+DotPosition:
+  EnforcedStyle: trailing
+
+DoubleNegation:
+  Enabled: false
+
+EachWithObject:
+  Enabled: false
+
+EmptyLiteral:
+  Enabled: false
+
+Encoding:
+  Enabled: false
+
+EvenOdd:
+  Enabled: false
+
+FileName:
+  Enabled: false
+
+FlipFlop:
+  Enabled: false
+
+FormatString:
+  Enabled: false
+
+GlobalVars:
+  Enabled: false
+
+GuardClause:
+  Enabled: true
+
+IfUnlessModifier:
+  Enabled: false
+
+IfWithSemicolon:
+  Enabled: false
+
+InlineComment:
+  Enabled: false
+
+Lambda:
+  Enabled: false
+
+LambdaCall:
+  Enabled: false
+
+LineEndConcatenation:
+  Enabled: false
+
+# LineLength:
+#   Max: 80
+
+MethodLength:
+  Enabled: false
+
+ModuleFunction:
+  Enabled: false
+
+NegatedIf:
+  Enabled: false
+
+NegatedWhile:
+  Enabled: false
+
+Next:
+  Enabled: false
+
+NilComparison:
+  Enabled: false
+
+Not:
+  Enabled: false
+
+NumericLiterals:
+  Enabled: false
+
+OneLineConditional:
+  Enabled: false
+
+Naming/BinaryOperatorParameterName:
+  Enabled: false
+
+ParameterLists:
+  Enabled: false
+
+PercentLiteralDelimiters:
+  Enabled: false
+
+PerlBackrefs:
+  Enabled: false
+
+PredicateName:
+  NamePrefixBlacklist:
+    - is_
+
+Proc:
+  Enabled: false
+
+RaiseArgs:
+  Enabled: false
+
+RegexpLiteral:
+  Enabled: false
+
+SelfAssignment:
+  Enabled: false
+
+SymbolArray:
+  Enabled: false
+
+SingleLineBlockParams:
+  Enabled: false
+
+SingleLineMethods:
+  Enabled: false
+
+SignalException:
+  Enabled: false
+
+SpecialGlobalVars:
+  Enabled: false
+
+StringLiterals:
+  EnforcedStyle: double_quotes
+
+VariableInterpolation:
+  Enabled: false
+
+Style/TrailingCommaInArrayLiteral:
+  Enabled: false
+
+Style/TrailingCommaInHashLiteral:
+  Enabled: false
+
+TrivialAccessors:
+  Enabled: false
+
+WhenThen:
+  Enabled: false
+
+WhileUntilModifier:
+  Enabled: false
+
+WordArray:
+  Enabled: false
+
+# Lint
+
+AmbiguousOperator:
+  Enabled: false
+
+AmbiguousRegexpLiteral:
+  Enabled: false
+
+AssignmentInCondition:
+  Enabled: false
+
+ConditionPosition:
+  Enabled: false
+
+DeprecatedClassMethods:
+  Enabled: false
+
+ElseLayout:
+  Enabled: false
+
+HandleExceptions:
+  Enabled: false
+
+LiteralAsCondition:
+  Enabled: false
+
+LiteralInInterpolation:
+  Enabled: false
+
+Loop:
+  Enabled: false
+
+ParenthesesAsGroupedExpression:
+  Enabled: false
+
+RequireParentheses:
+  Enabled: false
+
+UnderscorePrefixedVariableName:
+  Enabled: false
+
+Void:
+  Enabled: false
+
+# Overrides
+
+AbcSize:
+  Max: 20
+LineLength:
+  Description: 'Limit lines to 120 characters.'
+  Enabled: true
+  Max: 120
+Naming/ConstantName:
+  Description: 'Constants should use SCREAMING_SNAKE_CASE.'
+  StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#screaming-snake-case'
+  Enabled: true
+Naming/RescuedExceptionsVariableName:
+  PreferredName: exception
+CollectionMethods:
+  Enabled: false
+# StringLiteralsInInterpolation disabled because of a bug in rubocop https://github.com/bbatsov/rubocop/issues/1415
+StringLiteralsInInterpolation:
+  Enabled: false
+LeadingCommentSpace:
+  Enabled: false
+Rails:
+  Enabled: true
+Layout/IndentFirstArrayElement:
+  EnforcedStyle: consistent
+Layout/IndentFirstHashElement:
+  EnforcedStyle: consistent
+
+Metrics/BlockLength:
+  ExcludedMethods:
+    - context
+    - describe
+    - it
+    - xit
+    - xfeature
+    - xscenario
+    - xcontext
+    - shared_examples
+    - shared_examples_for
+    - scenario
+    - feature
+    - namespace
+    - resource
+    - patch
+    - get
+    - post
+    - put
+    - delete
+    - head
+    - example
+  Exclude:
+    - 'app/admin/**/*'
+    - 'lib/tasks/**/*'
+    - 'spec/**/*'
+
+AmbiguousBlockAssociation:
+  Exclude:
+    - 'spec/**/*'
+
+Rails/UnknownEnv:
+  Environments:
+    - newproduction
+    - development
+    - test
+    - staging


### PR DESCRIPTION
This PR extracts our Rubocop config to the patterns repo.

We can then pull it back into the project as required with the rubocop `inherit_from` setting.

https://github.com/rubocop-hq/rubocop/blob/master/manual/configuration.md#configuration