### PR TITLE
Require rubocop-rails

### DIFF
--- a/ruby/.rubocop.yml
+++ b/ruby/.rubocop.yml
@@ -1,3 +1,5 @@
+require: rubocop-rails
+
 AllCops:
   TargetRubyVersion: 2.6.2
   Exclude:


### PR DESCRIPTION
Closes https://github.com/BiggerPockets/biggerpockets/issues/8687

Solves the following types of warnings:

```
Warning: unrecognized cop ActionFilter found in .rubocop-https---raw-githubusercontent-com-BiggerPockets-patterns-master-ruby--rubocop-yml
```