### PR TITLE
Allow increment!

### DIFF
--- a/ruby/.rubocop.yml
+++ b/ruby/.rubocop.yml
@@ -337,3 +337,7 @@ Rails/UnknownEnv:
     - development
     - test
     - staging
+
+Rails/SkipsModelValidations:
+  Whitelist:
+    - increment!


### PR DESCRIPTION
increment! persists to the database and skips model validations. Normally this isn't a problem and we don't need warning about this.