### PR TITLE
Update Rubocop config

### DIFF
--- a/ruby/.rubocop.yml
+++ b/ruby/.rubocop.yml
@@ -172,8 +172,8 @@ PercentLiteralDelimiters:
 PerlBackrefs:
   Enabled: false
 
-PredicateName:
-  NamePrefixBlacklist:
+Naming/PredicateName:
+  ForbiddenPrefixes:
     - is_
 
 Proc:
@@ -247,7 +247,7 @@ DeprecatedClassMethods:
 ElseLayout:
   Enabled: false
 
-HandleExceptions:
+SuppressedException:
   Enabled: false
 
 LiteralAsCondition:
@@ -294,9 +294,9 @@ LeadingCommentSpace:
   Enabled: false
 Rails:
   Enabled: true
-Layout/IndentFirstArrayElement:
+Layout/FirstArrayElementIndentation:
   EnforcedStyle: consistent
-Layout/IndentFirstHashElement:
+Layout/FirstHashElementIndentation:
   EnforcedStyle: consistent
 
 Metrics/BlockLength:


### PR DESCRIPTION
Fixes:


Error: The `Layout/IndentFirstArrayElement` cop has been renamed to `Layout/FirstArrayElementIndentation`.
(obsolete configuration found in .rubocop-https---raw-githubusercontent-com-BiggerPockets-patterns-master-ruby--rubocop-yml, please update it)
The `Layout/IndentFirstHashElement` cop has been renamed to `Layout/FirstHashElementIndentation`.
(obsolete configuration found in .rubocop-https---raw-githubusercontent-com-BiggerPockets-patterns-master-ruby--rubocop-yml, please update it)
The `Lint/HandleExceptions` cop has been renamed to `Lint/SuppressedException`.
(obsolete configuration found in .rubocop-https---raw-githubusercontent-com-BiggerPockets-patterns-master-ruby--rubocop-yml, please update it)
obsolete parameter NamePrefixBlacklist (for Naming/PredicateName) found in .rubocop-https---raw-githubusercontent-com-BiggerPockets-patterns-master-ruby--rubocop-yml
`NamePrefixBlacklist` has been renamed to `ForbiddenPrefixes`.
