### PR TITLE
Brackets style for arrays of symbols and words

### DIFF
--- a/ruby/.rubocop.yml
+++ b/ruby/.rubocop.yml
@@ -222,7 +222,7 @@ Style/SpecialGlobalVars:
 Style/StringLiterals:
   EnforcedStyle: double_quotes
 Style/SymbolArray:
-  Enabled: false
+  EnforcedStyle: brackets
 Style/TrailingCommaInArrayLiteral:
   Enabled: false
 Style/TrailingCommaInHashLiteral:
@@ -236,4 +236,4 @@ Style/WhenThen:
 Style/WhileUntilModifier:
   Enabled: false
 Style/WordArray:
-  Enabled: false
+  EnforcedStyle: brackets


### PR DESCRIPTION
The majority of our codebase uses brackets rather than %i or %w to define array literals.

This change to our Rubocop config formalizes that.

https://rubocop.readthedocs.io/en/latest/cops_style/#stylewordarray

```rb
# good
["foo", "bar", "baz"]

# bad
%w[foo bar baz]
```

https://rubocop.readthedocs.io/en/latest/cops_style/#stylesymbolarray

```rb
# good
[:foo, :bar, :baz]

# bad
%i[foo bar baz]
```