### PR TITLE
Enforce trailing commas in hash and array literals

### DIFF
--- a/ruby/.rubocop.yml
+++ b/ruby/.rubocop.yml
@@ -224,9 +224,9 @@ Style/StringLiterals:
 Style/SymbolArray:
   Enabled: false
 Style/TrailingCommaInArrayLiteral:
-  Enabled: false
+  EnforcedStyleForMultiline: consistent_comma
 Style/TrailingCommaInHashLiteral:
-  Enabled: false
+  EnforcedStyleForMultiline: consistent_comma
 Style/TrivialAccessors:
   Enabled: false
 Style/VariableInterpolation:


### PR DESCRIPTION
Leaving a trailing comma on a multiline array or hash literal makes for a cleaner git diff. It also makes things consistent with our ESLint rules:

### Hash

```rb
# bad
a = { foo: 1, bar: 2, }

# good
a = { foo: 1, bar: 2 }

# good
a = {
  foo: 1, bar: 2,
  qux: 3,
}

# good
a = {
  foo: 1, bar: 2, qux: 3,
}

# good
a = {
  foo: 1,
  bar: 2,
}
```

### Array

```rb
# bad
a = [1, 2,]

# good
a = [1, 2]

# good
a = [
  1, 2,
  3,
]

# good
a = [
  1, 2, 3,
]

# good
a = [
  1,
  2,
]
```
