### PR TITLE
Update Rubocop config

### DIFF
--- a/ruby/.rubocop.yml
+++ b/ruby/.rubocop.yml
@@ -106,7 +106,7 @@ Naming/ConstantName:
 Naming/FileName:
   Enabled: false
 Naming/PredicateName:
-  NamePrefixBlacklist:
+  ForbiddenPrefixes:
     - is_
 Naming/RescuedExceptionsVariableName:
   PreferredName: exception


### PR DESCRIPTION
Follows https://github.com/rubocop-hq/rubocop/pull/7469

Fixes Rubocop linting for me. I guess we upgraded the Rubocop gem but not our config: https://github.com/BiggerPockets/biggerpockets/pull/10196