### PR TITLE
Enforce memoization instance variables begin with an underscore

### DIFF
--- a/ruby/.rubocop.yml
+++ b/ruby/.rubocop.yml
@@ -105,6 +105,8 @@ Naming/ConstantName:
   StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#screaming-snake-case'
 Naming/FileName:
   Enabled: false
+Naming/MemoizedInstanceVariableName:
+  EnforcedStyleForLeadingUnderscores: required
 Naming/PredicateName:
   ForbiddenPrefixes:
     - is_


### PR DESCRIPTION
Closes https://github.com/BiggerPockets/patterns/issues/60

This change enforces this rule:

```rb
# bad
def expensive_method
  @expensive_method ||= computation
end

# good
def expensive_method
  @_expensive_method ||= computation
end
```