### PR TITLE
Enable new cops and make multiline method arguments have a trailing comma

### DIFF
--- a/ruby/.rubocop.yml
+++ b/ruby/.rubocop.yml
@@ -2,6 +2,7 @@ require: rubocop-rails
 
 AllCops:
   TargetRubyVersion: 2.6.2
+  NewCops: enable
   Exclude:
     - db/schema.rb
     - bin/**/*
@@ -20,6 +21,9 @@ Layout/DotPosition:
   EnforcedStyle: trailing
 Layout/LeadingCommentSpace:
   Enabled: false
+Layout/LineLength:
+  Enabled: true
+  Max: 120
 
 Lint/AmbiguousBlockAssociation:
   Exclude:
@@ -85,9 +89,6 @@ Metrics/ClassLength:
   Enabled: false
 Metrics/CyclomaticComplexity:
   Enabled: false
-Metrics/LineLength:
-  Enabled: true
-  Max: 120
 Metrics/MethodLength:
   Enabled: false
 Metrics/ParameterLists:
@@ -226,6 +227,8 @@ Style/StringLiterals:
 Style/SymbolArray:
   EnforcedStyle: brackets
 Style/TrailingCommaInArrayLiteral:
+  EnforcedStyleForMultiline: consistent_comma
+Style/TrailingCommaInArguments:
   EnforcedStyleForMultiline: consistent_comma
 Style/TrailingCommaInHashLiteral:
   EnforcedStyleForMultiline: consistent_comma

--- a/ruby/.rubocop.yml
+++ b/ruby/.rubocop.yml
@@ -1,7 +1,7 @@
 require: rubocop-rails
 
 AllCops:
-  TargetRubyVersion: 2.6.2
+  TargetRubyVersion: 2.6.6
   NewCops: enable
   Exclude:
     - db/schema.rb


### PR DESCRIPTION
This PR enables new cops automatically.

It also enables TrailingCommaInArguments for multiline arguments:

```
# good

foo(bar)
foo(bar, baz)
foo(
  bar,
  baz,
)

# bad

foo(bar,)
foo(bar, baz,)
foo(
  bar,
  baz
)
```
