### PR TITLE
Address Rubocop warning

### DIFF
--- a/ruby/.rubocop.yml
+++ b/ruby/.rubocop.yml
@@ -122,7 +122,7 @@ Rails/ActionFilter:
 Rails/Delegate:
   Enabled: false
 Rails/SkipsModelValidations:
-  Whitelist:
+  AllowedMethods:
     - increment!
 Rails/UnknownEnv:
   Environments:


### PR DESCRIPTION
Fixes the following warning:

```
Warning: Rails/SkipsModelValidations does not support Whitelist parameter.

Supported parameters are:

  - Enabled
  - ForbiddenMethods
  - AllowedMethods
```