### PR TITLE
Rename ExcludedMethods to IgnoredMethods

### DIFF
--- a/ruby/.rubocop.yml
+++ b/ruby/.rubocop.yml
@@ -62,7 +62,7 @@ Metrics/BlockLength:
     - app/admin/**/*
     - lib/tasks/**/*
     - spec/**/*
-  ExcludedMethods:
+  IgnoredMethods:
     - context
     - describe
     - it


### PR DESCRIPTION
Fixes a warning I noticed locally.