### PR TITLE
Disable autocorrect for trailing comma cops

### DIFF
--- a/ruby/.rubocop.yml
+++ b/ruby/.rubocop.yml
@@ -228,10 +228,13 @@ Style/SymbolArray:
   EnforcedStyle: brackets
 Style/TrailingCommaInArrayLiteral:
   EnforcedStyleForMultiline: consistent_comma
+  AutoCorrect: false
 Style/TrailingCommaInArguments:
   EnforcedStyleForMultiline: consistent_comma
+  AutoCorrect: false
 Style/TrailingCommaInHashLiteral:
   EnforcedStyleForMultiline: consistent_comma
+  AutoCorrect: false
 Style/TrivialAccessors:
   Enabled: false
 Style/VariableInterpolation:


### PR DESCRIPTION
People who have their local environment set to autocorrect with Rubocop (the `-a` flag) are pushing commits that have broken autocorrects ([example](https://github.com/BiggerPockets/biggerpockets/pull/12940/commits/2e16e0ffedcb01c7fd266dde22094b7311a9e9cc#diff-69cfeb91ed2e903fff955435f51f2df6215e86ca76b96e47022dbf0f8f93480cR39))

This updates our Rubocop config so that these (obviously broken) autocorrect procedures do not run