### PR TITLE
Don't limit line length within test suite

### DIFF
--- a/ruby/.rubocop.yml
+++ b/ruby/.rubocop.yml
@@ -89,6 +89,8 @@ Metrics/CyclomaticComplexity:
 Metrics/LineLength:
   Enabled: true
   Max: 120
+  Exclude:
+    - spec/**/*
 Metrics/MethodLength:
   Enabled: false
 Metrics/ParameterLists:


### PR DESCRIPTION
Since we're now using RSpec tags specifically `flaky` and `driver: :legacy_headless_chrome` this check is being flagged / failed more often:

<img alt="Screenshot 2022-02-17 at 12 09 34" width="650" src="https://user-images.githubusercontent.com/666397/154478968-029241eb-36dc-447b-ab07-fae1016a5194.png">

I propose we simply exclude this rule from all files within `spec/**/*`