### PR TITLE
Disable Metrics/AbcSize

### DIFF
--- a/ruby/.rubocop.yml
+++ b/ruby/.rubocop.yml
@@ -53,7 +53,7 @@ Lint/Void:
   Enabled: false
 
 Metrics/AbcSize:
-  Max: 20
+  Enabled: false
 Metrics/BlockLength:
   Exclude:
     - app/admin/**/*


### PR DESCRIPTION
This nanny has a ton of false positives, we're now up to 40 ignores. Let's just go ahead and disable this and rely on code review to address function complexity issues.