### PR TITLE
Exclude db/data_schema.rb 

### DIFF
--- a/ruby/.rubocop.yml
+++ b/ruby/.rubocop.yml
@@ -5,6 +5,7 @@ AllCops:
   NewCops: enable
   Exclude:
     - db/schema.rb
+    - db/data_schema.rb
     - bin/**/*
     - client/**/*
     - public/**/*


### PR DESCRIPTION
Since the file `db/data_schema.rb` is automatically generated by [data-migrate](https://github.com/ilyakatz/data-migrate) I think it makes sense to exclude it from RoboCop. We already do this for `db/schema.rb`.