### PR TITLE
Disable Rails/DynamicFindBy cop

### DIFF
--- a/ruby/.rubocop.yml
+++ b/ruby/.rubocop.yml
@@ -127,6 +127,8 @@ Rails/ActionFilter:
   EnforcedStyle: action
 Rails/Delegate:
   Enabled: false
+Rails/DynamicFindBy:
+  Enabled: false
 Rails/SkipsModelValidations:
   AllowedMethods:
     - increment!


### PR DESCRIPTION
Any method named `find_by_*` is triggering `Rails/DynamicFindBy` errors. You can see an example [here](https://github.com/BiggerPockets/biggerpockets/pull/14839/files).

ActiveRecord used to provide dynamic find_by but it was [removed from Rails since Rails 5](https://github.com/rails/activerecord-deprecated_finders/blob/master/README.md). Since we're not using the gem `activerecord-deprecated_finders` and we're running on Rails `6.1.x` this cop offers no value and will only trigger false positives.