### PR TITLE
Fix ignoring BlockLength for ActiveAdmin

### DIFF
--- a/ruby/.rubocop.yml
+++ b/ruby/.rubocop.yml
@@ -57,7 +57,7 @@ Metrics/AbcSize:
   Enabled: false
 Metrics/BlockLength:
   Exclude:
-    - app/admin/**/*
+    - admin/**/*
     - config/**/*
     - db/**/*
     - lib/tasks/**/*


### PR DESCRIPTION
This commit fixes the path that's used for defining the large blocks
required by ActiveAdmin.