### PR TITLE
Fix headings in pattern

### DIFF
--- a/_patterns/dont-sleep.md
+++ b/_patterns/dont-sleep.md
@@ -7,22 +7,22 @@ Sometimes if we're waiting for some javascript to run or an operation to complet
 
 The problem is that this can create non-deterministic specs and forces our entire test suite to slow down based on how many seconds we `sleep`!
 
-## Bad
+## Bad
 
-````ruby
+```ruby
 sleep 1
-````
+```
 
-## Good
+## Good
 
-````ruby
+```ruby
 # Capybara will automatically wait until element is visible, up until a timeout
 expect(find("#element")).to have_content("login failed")
-````
+```
 
-## Bad
+## Bad
 
-````ruby
+```ruby
 stub_const("Livestream::LiveEvent::EXPIRATION_TIME", 1.second)
 
 Livestream::LiveEvent.update(foo: "bar")
@@ -30,11 +30,11 @@ Livestream::LiveEvent.update(foo: "bar")
 expect do
   sleep 1.5
 end.to change { Livestream::LiveEvent.exists? }.from(true).to(false)
-````
+```
 
-## Good
+## Good
 
-````ruby
+```ruby
 stub_const("Livestream::LiveEvent::EXPIRATION_TIME", 1.second)
 
 Livestream::LiveEvent.update(foo: "bar")
@@ -42,5 +42,5 @@ Livestream::LiveEvent.update(foo: "bar")
 expect do
   travel 2.seconds
 end.to change { Livestream::LiveEvent.exists? }.from(true).to(false)
-````
+```
 


### PR DESCRIPTION
These headings must include some invisible characters because Markdown wasn't identifying them as headings.