### PR TITLE
Ignore Rails' default blank lines at block start

### DIFF
--- a/ruby/.rubocop.yml
+++ b/ruby/.rubocop.yml
@@ -20,6 +20,9 @@ Layout/ConditionPosition:
   Enabled: false
 Layout/DotPosition:
   EnforcedStyle: trailing
+Layout/EmptyLinesAroundBlockBody:
+  Exclude:
+    - db/**/*
 Layout/LeadingCommentSpace:
   Enabled: false
 


### PR DESCRIPTION
Rails is going to keep adding these. Best to just ignore it.