### PR TITLE
Disable cop for perceived complexity

### DIFF
--- a/ruby/.rubocop.yml
+++ b/ruby/.rubocop.yml
@@ -103,6 +103,8 @@ Metrics/ModuleLength:
   Enabled: false
 Metrics/ParameterLists:
   Enabled: false
+Metrics/PerceivedComplexity:
+  Enabled: false
 
 Naming/AccessorMethodName:
   Enabled: false


### PR DESCRIPTION
While helpful, we're not often writing very complex new code, so this cop is flagging things that have barely changed. Instead I think it should be left up to reviewers to point out any new overly-complicated code.