### PR TITLE
[no-ticket] Remove noisy `Style/HashSyntax` Rubocop violations

### DIFF
--- a/ruby/.rubocop.yml
+++ b/ruby/.rubocop.yml
@@ -187,7 +187,7 @@ Style/GlobalVars:
 Style/GuardClause:
   Enabled: true
 Style/HashSyntax:
-  SupportedShorthandSyntax: either
+  EnforcedShorthandSyntax: either
 Style/IfUnlessModifier:
   Enabled: false
 Style/IfWithSemicolon:

--- a/ruby/.rubocop.yml
+++ b/ruby/.rubocop.yml
@@ -187,7 +187,7 @@ Style/GlobalVars:
 Style/GuardClause:
   Enabled: true
 Style/HashSyntax:
-  EnforcedShorthandSyntax: either
+  EnforcedShorthandSyntax: never
 Style/IfUnlessModifier:
   Enabled: false
 Style/IfWithSemicolon:

--- a/ruby/.rubocop.yml
+++ b/ruby/.rubocop.yml
@@ -186,6 +186,8 @@ Style/GlobalVars:
   Enabled: false
 Style/GuardClause:
   Enabled: true
+Style/HashSyntax:
+  SupportedShorthandSyntax: either
 Style/IfUnlessModifier:
   Enabled: false
 Style/IfWithSemicolon:


### PR DESCRIPTION
## What

Update Rubocop rules to force specifying hash values rather than omitting them with the new syntax in Ruby 3.1.

## Why

Our PRs are being littered with this warning:

<img width="685" alt="image" src="https://user-images.githubusercontent.com/22185/182594616-deafcf8b-e190-44ed-a8ad-78fa3f538854.png">

This is because latest version of Ruby (3.1+) allow omitting values from hashes. So Rubocop use this rule:

```ruby
# good
{foo: foo, bar: bar}

# good
{foo:, bar:}
```

This forces terseness onto the author using an unfamiliar syntax. Personally, I'm not a fan of this syntax as it makes it less clear what's going on.

For now, for consistency, force us to use the old syntax.

## How

Add `EnforcedShorthandSyntax: never` option so it forces us to be consistent and use the original style syntax.

If we want to add in the new style at some point in the future, we can change this to `always`.

## Testing

Updated my local `.rubocop.yml` file to:

```yaml
inherit_from: https://raw.githubusercontent.com/BiggerPockets/patterns/3db87366928a80f8b57a086b3d418fb64eaf22f3/ruby/.rubocop.yml
```

Ran `rubocop` on a file that had lots of these warnings and the warnings disappear. 🎉 
