### PR TITLE
Allow inline method scope declarations

### DIFF
--- a/ruby/.rubocop.yml
+++ b/ruby/.rubocop.yml
@@ -146,6 +146,8 @@ Rails/UnknownEnv:
     - review
     - production
 
+Style/AccessModifierDeclarations:
+  Enabled: false
 Style/Alias:
   Enabled: false
 Style/ArrayJoin:


### PR DESCRIPTION
I want to be able to privatize a method whilst keeping it in the context of related code. With Ruby 3, that's now an option, but we would need to disable the cop.

This change allows the following syntax form:

```ruby
private def super_secret_function
  # ...
end
```