### PR TITLE
Stop enforcing comma at the end of the line style that has little to no value

### DIFF
--- a/ruby/.rubocop.yml
+++ b/ruby/.rubocop.yml
@@ -245,13 +245,13 @@ Style/StringLiterals:
 Style/SymbolArray:
   EnforcedStyle: brackets
 Style/TrailingCommaInArrayLiteral:
-  EnforcedStyleForMultiline: consistent_comma
+  EnforcedStyleForMultiline: no_comma
   AutoCorrect: false
 Style/TrailingCommaInArguments:
-  EnforcedStyleForMultiline: consistent_comma
+  EnforcedStyleForMultiline: no_comma
   AutoCorrect: false
 Style/TrailingCommaInHashLiteral:
-  EnforcedStyleForMultiline: consistent_comma
+  EnforcedStyleForMultiline: no_comma
   AutoCorrect: false
 Style/TrivialAccessors:
   Enabled: false


### PR DESCRIPTION
## What

Stop an annoying linting rule that has little to no value apart from wasting time.

## Why

* Adding trailing commas is against most standard Ruby examples 
* Adding trailing commas in an array is misleading at best and wrong at worst
* I keep forgetting this silly rule (because I've never had to do it in my professional career) and as a result I waste time linting things that don't need to be linted

## How

Change the rule to use `comma` which is the default.

**Who's with me?**