### PR TITLE
Rename obsolete IgnoredMethods to AllowedMethods

### DIFF
--- a/ruby/.rubocop.yml
+++ b/ruby/.rubocop.yml
@@ -70,7 +70,7 @@ Metrics/BlockLength:
     - db/**/*
     - lib/tasks/**/*
     - spec/**/*
-  IgnoredMethods:
+  AllowedMethods:
     - context
     - describe
     - it


### PR DESCRIPTION
Ref https://github.com/rubocop/rubocop/pull/10829

```shell
Warning: obsolete parameter `IgnoredMethods` (for `Metrics/BlockLength`) found in .rubocop-https---raw-githubusercontent-com-BiggerPockets-patterns-master-ruby--rubocop-yml `IgnoredMethods` has been renamed to `AllowedMethods` and/or `AllowedPatterns`.
```