### PR TITLE
Describe features at a high level rather than querying the user model directly

### DIFF
--- a/_patterns/use-feature-repo-for-feature-access-checks.md
+++ b/_patterns/use-feature-repo-for-feature-access-checks.md
@@ -1,6 +1,6 @@
 ---
 categories: Ruby
-name: Use feature repo for feature access checks
+name: Describe features at a high level rather than querying the user model directly
 ---
 
 ## Context
@@ -16,10 +16,9 @@ name: Use feature repo for feature access checks
 
 ## Solution
 
-* There's a single place for all feature configuration to be stored - [the `FeatureRepo`](https://github.com/BiggerPockets/biggerpockets/blob/86ee130dce1a272dd5ad59689ed4226de24bac89/lib/features/feature_repo.rb#L10)
 * Features are named using a namespace
 * Features are configured with a `:subscription_level`, `:enabled` or `:value`
-* Features can be checked with `FeatureRepo#enabled?` or `FeatureRepo#value`
+* Features can be accessed with `feature.enabled?`, `feature.disabled?` or `feature.value`
 
 ## Bad
 
@@ -56,39 +55,5 @@ class PaidReportsController < ApplicationController
     # ...
   end
   # ...
-end
-```
-
-Then in the `Features` module:
-
-```ruby
-# lib/features/feature_repo.rb
-
-module Features
-  FEATURES = {
-    # ...
-    "membership.reporting.report_access_allowed" => [
-      { subscription_level: :premium, enabled: true },
-      { subscription_level: :none, enabled: false }
-    ],
-    # ...
-  }
-  # ...
-end
-```
-
-You may need to add the app name:
-
-```ruby
-# lib/events/event.rb
-
-module Events
-  class Event < Dry::Struct
-    # ...
-    APP_NAMES = {
-      "membership.reporting" => "Membership Reporting",
-      # ...
-    }
-  end
 end
 ```

--- a/_patterns/use-feature-repo-for-feature-access-checks.md
+++ b/_patterns/use-feature-repo-for-feature-access-checks.md
@@ -1,0 +1,97 @@
+---
+categories: Ruby
+name: Use feature repo for feature access checks
+---
+
+## Context
+
+* We had lots of code inside controllers and views checking for methods like `#has_premium_benefits?` on user
+* This code determines if the user has access to a **feature**
+
+## Problem
+
+* When a change is made to features or how access is granted, we need to make many changes throughout the codebase
+* We cannot at a glance see which features the app contains, or which subscription levels have access to them
+* The concept of a "feature" is missing from the code so it doesn't communicate intent as clearly as it could do
+
+## Solution
+
+* There's a single place for all feature configuration to be stored - [the `FeatureRepo`](https://github.com/BiggerPockets/biggerpockets/blob/86ee130dce1a272dd5ad59689ed4226de24bac89/lib/features/feature_repo.rb#L10)
+* Features are named using a namespace
+* Features are configured with a `:subscription_level`, `:enabled` or `:value`
+* Features can be checked with `FeatureRepo#enabled?` or `FeatureRepo#value`
+
+## Bad
+
+```ruby
+class WebinarBonusesController < ApplicationController
+  before_action :require_annual, only: :create
+
+  def create
+    # ...
+  end
+
+  def require_annual
+    return if current_user.paid_annual? || current_user.has_premium_benefits?
+
+    # ...
+  end
+  # ...
+end
+```
+
+Taken from the code [as it used to be](https://github.com/BiggerPockets/biggerpockets/blob/eadc8aa5cf73b2d697a12b9cdff28f2421e0ca6e/app/controllers/webinar_bonuses_controller.rb#L41-L46).
+
+## Good
+
+```ruby
+class WebinarBonusesController < ApplicationController
+  before_action :require_annual, only: :create
+
+  def create
+    # ...
+  end
+
+ def require_annual
+    return if feature.enabled?("membership.signup.access_to_webinar_bonuses", user: current_user)
+
+    # ...
+  end
+  # ...
+end
+```
+
+Then in the `Features` module:
+
+```ruby
+# lib/features/feature_repo.rb
+
+module Features
+  FEATURES = {
+    # ...
+    "membership.signup.access_to_webinar_bonuses" => [ # <== 
+      { subscription_level: :premium, enabled: true },
+      { subscription_level: :pro, subscription_period: :annual, enabled: true },
+      { subscription_level: :none, enabled: false }
+    ],
+    # ...
+  }
+  # ...
+end
+```
+
+You may need to add the app name:
+
+```ruby
+# lib/events/event.rb
+
+module Events
+  class Event < Dry::Struct
+    # ...
+    APP_NAMES = {
+      "membership.signup" => "Membership signup",
+      # ...
+    }
+  end
+end
+```

--- a/_patterns/use-feature-repo-for-feature-access-checks.md
+++ b/_patterns/use-feature-repo-for-feature-access-checks.md
@@ -6,13 +6,13 @@ name: Use feature repo for feature access checks
 ## Context
 
 * We had lots of code inside controllers and views checking for methods like `#has_premium_benefits?` on user
-* This code determines if the user has access to a **feature**
+* This code is really checking if the user has access to a feature
 
 ## Problem
 
-* When a change is made to features or how access is granted, we need to make many changes throughout the codebase
-* We cannot at a glance see which features the app contains, or which subscription levels have access to them
-* The concept of a "feature" is missing from the code so it doesn't communicate intent as clearly as it could do
+* Code is brittle - one change to how subscriptions work mean shotgun surgery on the codebase
+* Difficult to reason about features - we can't see in one place the features of the app or which subscription levels are granted access
+* Code doesn't communicate intent - the concept of a "feature" is missing
 
 ## Solution
 


### PR DESCRIPTION
## What

The platform team have recently added a `Features::FeatureRepo` that contains all feature definitions.

Let's use this for any features we need to define in future.

## Why

So that we can have consistency in how we define features and be able to see them all in one place.