### PR TITLE
Update RoboCop target Ruby version to 3.2

### DIFF
--- a/ruby/.rubocop.yml
+++ b/ruby/.rubocop.yml
@@ -1,7 +1,7 @@
 require: rubocop-rails
 
 AllCops:
-  TargetRubyVersion: 3.1.2
+  TargetRubyVersion: 3.2
   NewCops: enable
   Exclude:
     - db/schema.rb


### PR DESCRIPTION
Since we upgraded, we're no longer using Ruby `3.1.2`, so we should now target Ruby `3.2`. I've left this as `3.2` rather than `3.2.0` so you don't have to micromanage this variable for patch-level improvements.