### PR TITLE
Disable Layout/LineLength cop

### DIFF
--- a/ruby/.rubocop.yml
+++ b/ruby/.rubocop.yml
@@ -27,7 +27,6 @@ Layout/LeadingCommentSpace:
   Enabled: false
 Layout/LineLength:
   Enabled: false
-
 Lint/AmbiguousBlockAssociation:
   Exclude:
     - spec/**/*

--- a/ruby/.rubocop.yml
+++ b/ruby/.rubocop.yml
@@ -26,10 +26,7 @@ Layout/EmptyLinesAroundBlockBody:
 Layout/LeadingCommentSpace:
   Enabled: false
 Layout/LineLength:
-  Enabled: true
-  Max: 120
-  Exclude:
-    - spec/**/*
+  Enabled: false
 
 Lint/AmbiguousBlockAssociation:
   Exclude:


### PR DESCRIPTION
During our weekly pairing session @petershutt and I wrote a script to count the number of Robocop warnings that have been ignored in the last month, Jan 9 2023 - Feb 9 2023, we found the team has ignored `Layout/LineLength` 31 times.

We already disabled this cop for the test suite, and I'd like to propose we disable it completely. 

For anyone curious, the complete list is

| Ignored count  | Cop name |
| ------------- | ------------- |
| 31 | `Layout/LineLength` |
| 4  | `Rails/SkipsModelValidations` |
| 3  | `Style/FrozenStringLiteralComment` |
| 2  | `Style/MutableConstant` |
| 2  | `Style/WordArray` |
| 2  | `Style/OpenStructUse` |
| 2  | `Rails/OutputSafety` |
| 2  | `Rails/I18nLocaleTexts` |
| 2  | `Style/StringLiterals` |
| 2  | `Lint/UselessAssignment` |
| 2  | `Layout/HeredocIndentation` |
| 1  | `Layout/TrailingEmptyLines` |
| 1  | `Style/RedundantInitialize` |
| 1  | `Style/GuardClause` |
| 1  | `Layout/SpaceInsideHashLiteralBraces` |
| 1  | `Rails/FilePath` |
| 1  | `Style/ClassAndModuleChildren` |
| 1  | `Style/InverseMethods` |
| 1  | `Layout/EmptyLines` |
| 1  | `Layout/TrailingWhitespace` |
| 1  | `Style/StringLiteralsInInterpolation` |
| 1  | `Lint/MissingSuper` |
| 1  | `Layout/ClosingParenthesisIndentation` |