### PR TITLE
Disable Rails/RedundantPresenceValidationOnBelongsTo rubocop rule

### DIFF
--- a/ruby/.rubocop.yml
+++ b/ruby/.rubocop.yml
@@ -137,6 +137,8 @@ Rails/Delegate:
   Enabled: false
 Rails/DynamicFindBy:
   Enabled: false
+Rails/RedundantPresenceValidationOnBelongsTo:
+  Enabled: false
 Rails/SkipsModelValidations:
   AllowedMethods:
     - increment!


### PR DESCRIPTION
We have `config.active_record.belongs_to_required_by_default` set to `false`, so we need to explicitly set that validation when needed.

https://www.rubydoc.info/gems/rubocop-rails/RuboCop/Cop/Rails/RedundantPresenceValidationOnBelongsTo
> Since Rails 5.0 the default for `belongs_to` is `optional: false` unless `config.active_record.belongs_to_required_by_default` is explicitly set to `false`. The presence validator is added automatically, and explicit presence validation is redundant.