### PR TITLE
Exclude db/data_schema.rb from magic string cop

### DIFF
--- a/ruby/.rubocop.yml
+++ b/ruby/.rubocop.yml
@@ -22,6 +22,9 @@ Layout/ConditionPosition:
   Enabled: false
 Layout/DotPosition:
   EnforcedStyle: trailing
+Layout/EmptyLineAfterMagicComment:
+  Exclude:
+    - db/data_schema.rb
 Layout/EmptyLinesAroundBlockBody:
   Exclude:
     - db/**/*
@@ -186,6 +189,9 @@ Style/Encoding:
   Enabled: false
 Style/EvenOdd:
   Enabled: false
+Style/FrozenStringLiteralComment:
+  Exclude:
+    - db/data_schema.rb
 Style/FormatString:
   Enabled: false
 Style/GlobalVars:


### PR DESCRIPTION
This file is automatically managed and should not be scanned by rubocop.

These cops should be ignored via the `AllCops` directive, but they're not.