### PR TITLE
Don't consider line length in schema.rb

### DIFF
--- a/ruby/.rubocop.yml
+++ b/ruby/.rubocop.yml
@@ -32,6 +32,7 @@ Layout/LineLength:
   Max: 120
   Exclude:
     - !ruby/regexp /spec\/(?!components\/previews)/
+    - db/schema.rb
 
 Lint/AmbiguousBlockAssociation:
   Exclude:


### PR DESCRIPTION
Not sure why, but reviewdog or rubocop is not properly excluding this from cops via the AllCops directive.