### PR TITLE
RuboCop allow `update_counters`

### DIFF
--- a/ruby/.rubocop.yml
+++ b/ruby/.rubocop.yml
@@ -143,6 +143,7 @@ Rails/RedundantPresenceValidationOnBelongsTo:
 Rails/SkipsModelValidations:
   AllowedMethods:
     - increment!
+    - update_counters
 Rails/UnknownEnv:
   Environments:
     - test


### PR DESCRIPTION
We have been utilizing [`#update_counters`](https://api.rubyonrails.org/classes/ActiveRecord/CounterCache/ClassMethods.html#method-i-update_counters) in ActiveRecord to avoid race conditions, as explained in this article: https://www.honeybadger.io/blog/activerecord-update-counters-race-conditions/

However, every time we use this method, it attracts unwanted attention from the authorities, and we must manually evade them.

It would be logical to exclude [`#update_counters`](https://api.rubyonrails.org/classes/ActiveRecord/CounterCache/ClassMethods.html#method-i-update_counters) from [Rails/SkipsModelValidations](https://www.rubydoc.info/gems/rubocop/0.51.0/RuboCop/Cop/Rails/SkipsModelValidations). This is because when using it, it is likely to be either for updating a counter cache or to ensure atomicity. In either of these scenarios, having more precise control over which callbacks/validations are triggered is preferable, so you would want to avoid following its advice.