### PR TITLE
Prefer shortened namespaces

### DIFF
--- a/_patterns/prefer-shortened-namespaces.md
+++ b/_patterns/prefer-shortened-namespaces.md
@@ -1,0 +1,43 @@
+---
+categories: Ruby
+name: Prefer shortened namespaces
+---
+
+Ruby provides a way to reference other classes and modules using relative references from within the current namespace or any parent namespace, which allows you to omit the leading namespace qualifier.
+Shortened names tend to be more readable specially when we have long namespaces.
+
+## Bad
+
+````ruby
+module SomeArea
+  module SomeApp
+    module SomeComponent
+      class MyClass
+        ...
+
+        def my_method
+          SomeArea::SomeApp::MyOtherClass.new
+        end
+      end
+    end
+  end
+end
+````
+
+## Good
+
+````ruby
+module SomeArea
+  module SomeApp
+    module SomeComponent
+      class MyClass
+        ...
+
+        def my_method
+          MyOtherClass.new
+        end
+      end
+    end
+  end
+end
+````

--- a/_patterns/prefer-shortened-namespaces.md
+++ b/_patterns/prefer-shortened-namespaces.md
@@ -13,8 +13,6 @@ module SomeArea
   module SomeApp
     module SomeComponent
       class MyClass
-        ...
-
         def my_method
           SomeArea::SomeApp::MyOtherClass.new
         end
@@ -31,8 +29,6 @@ module SomeArea
   module SomeApp
     module SomeComponent
       class MyClass
-        ...
-
         def my_method
           MyOtherClass.new
         end


### PR DESCRIPTION
## Why
- To make the codebase more readable
- To make the codebase more consistent
- To address some of the very long namespaces