### PR TITLE
Disable Rails/SkipsModelValidations

### DIFF
--- a/ruby/.rubocop.yml
+++ b/ruby/.rubocop.yml
@@ -147,9 +147,7 @@ Rails/DynamicFindBy:
 Rails/RedundantPresenceValidationOnBelongsTo:
   Enabled: false
 Rails/SkipsModelValidations:
-  AllowedMethods:
-    - increment!
-    - update_counters
+  Enabled: false
 Rails/UnknownEnv:
   Environments:
     - test


### PR DESCRIPTION
This cop checks for the use of methods which skip validations which are listed in [guides.rubyonrails.org/active_record_validations.html#skipping-validations](http://guides.rubyonrails.org/active_record_validations.html#skipping-validations)

There are many situations where we legitimately want to skip validations. 

For example: 
- https://github.com/BiggerPockets/biggerpockets/pull/18828
- https://github.com/BiggerPockets/biggerpockets/blob/f1d72c6ab7f7b98469c5b0bc6ecb1c4bc663131b/lib/migrations/backfill_insecure_password_to_social_users.rb
- https://github.com/BiggerPockets/biggerpockets/blob/5ef53618a03421e987f02acc9483632b01fb8d5f/app/controllers/api/v1/notifications_controller.rb#L37-L39

Currently, in the codebase, we've written `# rubocop:disable Rails/SkipsModelValidations` 65 times, and I expect there to be many more.

There are also 237 offences detected for this check.

Do folks find this check helpful, or can we disable it?
