### PR TITLE
Disable Rails/Output

### DIFF
--- a/ruby/.rubocop.yml
+++ b/ruby/.rubocop.yml
@@ -157,6 +157,8 @@ Rails/UnknownEnv:
     - staging
     - review
     - production
+Rails/Output:
+  Enabled: false
 
 Style/AccessModifierDeclarations:
   Enabled: false


### PR DESCRIPTION
This cops checks for the use of output calls like puts and print

```
# bad
puts 'A debug message'
pp 'A debug message'
print 'A debug message'

# good
[Rails](https://www.rubydoc.info/gems/rubocop-rails/RuboCop/Cop/Rails).logger.debug 'A debug message'
```

It's important to note that there are situations where we legitimately want to print to Stdout. For instance:

- https://github.com/BiggerPockets/biggerpockets/pull/18701#pullrequestreview-1584751210
- https://github.com/BiggerPockets/biggerpockets/blob/beccaf3f2b75459f02793355ef81ac2d47d61be4/lib/generators/widget/widget_generator.rb#L13

We should keep in mind that people might blindly follow the cop's advice without considering circumstantial nuances, which can sometimes cause more hassle than it's worth.
