### PR TITLE
Exclude db/insights2_schema.rb from rubocop

### DIFF
--- a/ruby/.rubocop.yml
+++ b/ruby/.rubocop.yml
@@ -7,6 +7,7 @@ AllCops:
   NewCops: enable
   Exclude:
     - db/schema.rb
+    - db/insights2_schema.rb
     - db/data_schema.rb
     - bin/**/*
     - client/**/*


### PR DESCRIPTION
This file is automatically generated, so we shouldn't attempt to lint it via Rubocop since no violation can be actioned.