### PR TITLE
Add RuboCop RSpec/Capybara

### DIFF
--- a/ruby/.rubocop.yml
+++ b/ruby/.rubocop.yml
@@ -1,6 +1,7 @@
 require:
   - rubocop-rails
   - rubocop-performance
+  - rubocop-rspec
 
 AllCops:
   TargetRubyVersion: 3.2

--- a/ruby/.rubocop.yml
+++ b/ruby/.rubocop.yml
@@ -2,6 +2,7 @@ require:
   - rubocop-rails
   - rubocop-performance
   - rubocop-rspec
+  - rubocop-capybara
 
 AllCops:
   TargetRubyVersion: 3.2
@@ -16,6 +17,12 @@ AllCops:
     - script/**/*
     - vendor/**/*
     - node_modules/**/*
+
+RSpec:
+ Enabled: false
+
+RSpec/Capybara:
+  Enabled: true
 
 Bundler/OrderedGems:
   Enabled: false


### PR DESCRIPTION
RuboCop RSpec is an [official extension](https://docs.rubocop.org/rubocop/extensions.html#official-extensions) of RuboCop focused on enforcing the guidelines and best practices outlined in the community [RSpec style guide](https://rspec.rubystyle.guide/). 

It contains [RSpec/Capybara](https://docs.rubocop.org/rubocop-rspec/cops_rspec_capybara.html), which, amongst other things, offers suggestions on how to interact with Capybara in a manner which avoids accidentally writing flaky specs.

Some illustrative examples of the types of suggestions it adds are:

[RSpec/Capybara/CurrentPathExpectation](https://docs.rubocop.org/rubocop-rspec/cops_rspec_capybara.html#rspeccapybaracurrentpathexpectation)

```ruby
# bad
expect(current_path).to eq('/callback')

# good
expect(page).to have_current_path('/callback')

# bad (does not support autocorrection)
expect(page.current_path).to match(variable)

# good
expect(page).to have_current_path('/callback')
```

[RSpec/Capybara/SpecificActions](https://docs.rubocop.org/rubocop-rspec/cops_rspec_capybara.html#rspeccapybaraspecificactions)

```ruby
# bad
find('a').click
find('button.cls').click
find('a', exact_text: 'foo').click
find('div button').click

# good
click_link
click_button(class: 'cls')
click_link(exact_text: 'foo')
find('div').click_button
```

I find it helpful on my personal projects and think it could be beneficial for BiggerPockets