### PR TITLE
Remove trailing comma rule

### DIFF
--- a/ruby/.rubocop.yml
+++ b/ruby/.rubocop.yml
@@ -270,9 +270,3 @@ Style/WhileUntilModifier:
   Enabled: false
 Style/WordArray:
   EnforcedStyle: brackets
-Style/TrailingCommaInArrayLiteral:
-  EnforcedStyleForMultiline: consistent_comma
-Style/TrailingCommaInArguments:
-  EnforcedStyleForMultiline: consistent_comma
-Style/TrailingCommaInHashLiteral:
-  EnforcedStyleForMultiline: consistent_comma


### PR DESCRIPTION
I suggest we remove enforcing trailing comma due to the following reasons:
- When trailing comma is missed, fixing it prolongs the pull request iteration process, as developers must wait for the CI to pass again after addressing this issue.

- Trailing comma was not originally enforced, so additional modifications are often necessary to satisfy rubocop introducing unnecessary changes.

- Ruby prohibits the use of a comma at the end of attributes spread across multiple lines, which creates inconsistencies like this: 
<img width="455" alt="Screenshot 2024-02-20 at 1 31 25 pm" src="https://github.com/BiggerPockets/patterns/assets/1279673/de95e3b4-40d3-4efb-b73c-285ee203ad34">
