### PR TITLE
Add preferred http client

### DIFF
--- a/_patterns/prefer_faraday_as_http_client.md
+++ b/_patterns/prefer_faraday_as_http_client.md
@@ -5,7 +5,7 @@ name: Prefer Faraday as default HTTP client
 
 Prefer Faraday as the default HTTP client because of the following:
 1. It is faster than Httpparty (Speed comparison: https://www.scrapingdog.com/blog/ruby-http-clients/)
-2. It has a retry ability at the middleware layer
+2. It has a retry ability with the `FaradayMiddleware::Retry` middleware
 3. It is more flexible as it supports many underlying adapters
 4. It does not make sense to have multiple HTTP clients in the same project. When we have
    one we can set one open/read timeout and other global configuration options.
@@ -23,6 +23,19 @@ puts "Response code: #{response.code}"
 puts "Response body: #{response.body}"
 ```
 
+### Retry ability
+
+Httpparty does not have any mechanism for retrying requests.
+
+There is a gem called extended_httpparty (https://github.com/zaagan/extended-httparty)
+that adds retry ability. But this is not very popular and does not seem to be maintained.
+Also, retries have be set on each request.
+
+```
+response = ExtendedHttparty.get('http://api.stackexchange.com/2.2/questions?site=stackoverflow', tries: 5)
+```
+
+
 ## Good
 
 ```
@@ -37,4 +50,27 @@ response = conn.get('/posts/1')
 # Print response information
 puts "Response code: #{response.status}"
 puts "Response body: #{response.body}"
+```
+
+### Retry ability
+
+Faraday has a middleware called `FaradayMiddleware::Retry` that can be used to retry requests.
+This is more flexible than extended_httpparty the Faraday instance can be initialized
+globally with retry options.
+
+```ruby
+require 'faraday'
+require 'faraday/retry'
+
+retry_options = {
+  max: 2,
+  interval: 0.05,
+  interval_randomness: 0.5,
+  backoff_factor: 2
+}
+
+conn = Faraday.new(...) do |f|
+  f.request :retry, retry_options
+  #...
+end
 ```

--- a/_patterns/prefer_faraday_as_http_client.md
+++ b/_patterns/prefer_faraday_as_http_client.md
@@ -3,66 +3,46 @@ categories: Ruby
 name: Prefer Faraday as default HTTP client
 ---
 
-Prefer Faraday as the default HTTP client because of the following:
-1. It is faster than Httpparty (Speed comparison: https://www.scrapingdog.com/blog/ruby-http-clients/)
-2. It allows for a global connection configuration for setting open/read timeout, retries, etc.
-3. It has advanced retry ability with the `FaradayMiddleware::Retry` middleware
-4. It is more flexible as it supports many underlying adapters
-5. It does not make sense to have multiple HTTP clients in the same project. When we have
-   one we can set one open/read timeout and other global configuration options.
+Prefer Faraday as the default HTTP client
+
+## Pros
+
+* Global configuration options - open/read timeout, retries, etc.
+* Configure retries using `FaradayMiddleware::Retry`
+* Easily extend with middleware, e.g. [decoding JSON](https://github.com/BiggerPockets/biggerpockets/blob/37f31a80fe0f6a76c3b094fec706a1c7ac71e70d/app/models/insights/altos_rental_latest_date.rb#L32)
+* Faster than httparty (speed comparison: https://www.scrapingdog.com/blog/ruby-http-clients/)
+* Supports multiple adapters (Net::HTTP, Typhoeus, Patron, Excon, etc.)
 
 ## Bad
 
-Httpparty has to be configured at a request level so request options have to be explicitly
-set for each request. This is not ideal because it is easy to forget to set
-a configuration and it is harder to have unified configuration options for all requests.
-Also, the retry gem associated with Httpparty is not very popular and does not have a lot
-of timeout options.
-
 ```ruby
 require 'httparty'
+require 'extended_httparty'
 
-# Make a GET request
+# GET request
 response = HTTParty.get('https://jsonplaceholder.typicode.com/posts/1', timeout: 5)
+# GET request with retry
+response = ExtendedHttparty.get('https://jsonplaceholder.typicode.com/posts/1', tries: 5)
 
-# Print response information
-puts "Response code: #{response.code}"
-puts "Response body: #{response.body}"
+External gem for retrying requests with httparty
 ```
-
-External gem for retrying requests with Httpparty
-
-```ruby
-response = ExtendedHttparty.get('http://api.stackexchange.com/2.2/questions?site=stackoverflow', tries: 5)
-```
-
 
 ## Good
 
-Faraday can be set up at a connection level with global configuration options. This means
-that all requests made with the Faraday instance will have the same configuration options
-such as open/read timeout, retries, etc.
-
-Retries can be set up with the `FaradayMiddleware::Retry` middleware.
-
-
-```ruby
-require 'faraday'
-require 'faraday/retry'
-
-retry_options = {
-  max: 2,
-  interval: 0.05,
-  interval_randomness: 0.5,
-  backoff_factor: 2,
-  timeout: 2,
-}
-
-conn = Faraday.new(...) do |f|
-  f.request :retry, retry_options
-  #...
-end
-
-con.get('https://jsonplaceholder.typicode.com/posts/1')
 ```
+require 'faraday'
+# GET request
+Faraday.get('https://jsonplaceholder.typicode.com/posts/1')
+# GET request with retry
+require 'faraday/retry'
+conn = Faraday.new do |f|
+  f.request :retry, {
+    max: 2,
+    interval: 0.05,
+    interval_randomness: 0.5,
+    backoff_factor: 2,
+    timeout: 2,
+  }
+end
+conn.get('https://jsonplaceholder.typicode.com/posts/1')
 ```

--- a/_patterns/prefer_faraday_as_http_client.md
+++ b/_patterns/prefer_faraday_as_http_client.md
@@ -5,58 +5,46 @@ name: Prefer Faraday as default HTTP client
 
 Prefer Faraday as the default HTTP client because of the following:
 1. It is faster than Httpparty (Speed comparison: https://www.scrapingdog.com/blog/ruby-http-clients/)
-2. It has a retry ability with the `FaradayMiddleware::Retry` middleware
-3. It is more flexible as it supports many underlying adapters
-4. It does not make sense to have multiple HTTP clients in the same project. When we have
+2. It allows for a global connection configuration for setting open/read timeout, retries, etc.
+3. It has advanced retry ability with the `FaradayMiddleware::Retry` middleware
+4. It is more flexible as it supports many underlying adapters
+5. It does not make sense to have multiple HTTP clients in the same project. When we have
    one we can set one open/read timeout and other global configuration options.
 
 ## Bad
 
-```
+Httpparty has to be configured at a request level so request options have to be explicitly
+set for each request. This is not ideal because it is easy to forget to set
+a configuration and it is harder to have unified configuration options for all requests.
+Also, the retry gem associated with Httpparty is not very popular and does not have a lot
+of timeout options.
+
+```ruby
 require 'httparty'
 
 # Make a GET request
-response = HTTParty.get('https://jsonplaceholder.typicode.com/posts/1')
+response = HTTParty.get('https://jsonplaceholder.typicode.com/posts/1', timeout: 5)
 
 # Print response information
 puts "Response code: #{response.code}"
 puts "Response body: #{response.body}"
 ```
 
-### Retry ability
+External gem for retrying requests with Httpparty
 
-Httpparty does not have any mechanism for retrying requests.
-
-There is a gem called extended_httpparty (https://github.com/zaagan/extended-httparty)
-that adds retry ability. But this is not very popular and does not seem to be maintained.
-Also, retries have be set on each request.
-
-```
+```ruby
 response = ExtendedHttparty.get('http://api.stackexchange.com/2.2/questions?site=stackoverflow', tries: 5)
 ```
 
 
 ## Good
 
-```
-require 'faraday'
+Faraday can be set up at a connection level with global configuration options. This means
+that all requests made with the Faraday instance will have the same configuration options
+such as open/read timeout, retries, etc.
 
-# Create a Faraday connection
-conn = Faraday.new(url: 'https://jsonplaceholder.typicode.com')
+Retries can be set up with the `FaradayMiddleware::Retry` middleware.
 
-# Make a GET request
-response = conn.get('/posts/1')
-
-# Print response information
-puts "Response code: #{response.status}"
-puts "Response body: #{response.body}"
-```
-
-### Retry ability
-
-Faraday has a middleware called `FaradayMiddleware::Retry` that can be used to retry requests.
-This is more flexible than extended_httpparty the Faraday instance can be initialized
-globally with retry options.
 
 ```ruby
 require 'faraday'
@@ -66,11 +54,15 @@ retry_options = {
   max: 2,
   interval: 0.05,
   interval_randomness: 0.5,
-  backoff_factor: 2
+  backoff_factor: 2,
+  timeout: 2,
 }
 
 conn = Faraday.new(...) do |f|
   f.request :retry, retry_options
   #...
 end
+
+con.get('https://jsonplaceholder.typicode.com/posts/1')
+```
 ```

--- a/_patterns/prefer_faraday_as_http_client.md
+++ b/_patterns/prefer_faraday_as_http_client.md
@@ -1,0 +1,10 @@
+---
+categories: Ruby
+name: Prefer Faraday as default HTTP client
+---
+
+Prefer Faraday as the default HTTP client because of the following:
+1. It is faster
+2. It is more flexible
+3. It does not make sense to have multiple HTTP clients in the same project
+

--- a/_patterns/prefer_faraday_as_http_client.md
+++ b/_patterns/prefer_faraday_as_http_client.md
@@ -4,9 +4,11 @@ name: Prefer Faraday as default HTTP client
 ---
 
 Prefer Faraday as the default HTTP client because of the following:
-1. It is faster
-2. It is more flexible as it supports many underlying adapters
-3. It does not make sense to have multiple HTTP clients in the same project
+1. It is faster than Httpparty (Speed comparison: https://www.scrapingdog.com/blog/ruby-http-clients/)
+2. It has a retry ability at the middleware layer
+3. It is more flexible as it supports many underlying adapters
+4. It does not make sense to have multiple HTTP clients in the same project. When we have
+   one we can set one open/read timeout and other global configuration options.
 
 ## Bad
 
@@ -36,4 +38,3 @@ response = conn.get('/posts/1')
 puts "Response code: #{response.status}"
 puts "Response body: #{response.body}"
 ```
-

--- a/_patterns/prefer_faraday_as_http_client.md
+++ b/_patterns/prefer_faraday_as_http_client.md
@@ -5,6 +5,35 @@ name: Prefer Faraday as default HTTP client
 
 Prefer Faraday as the default HTTP client because of the following:
 1. It is faster
-2. It is more flexible
+2. It is more flexible as it supports many underlying adapters
 3. It does not make sense to have multiple HTTP clients in the same project
+
+## Bad
+
+```
+require 'httparty'
+
+# Make a GET request
+response = HTTParty.get('https://jsonplaceholder.typicode.com/posts/1')
+
+# Print response information
+puts "Response code: #{response.code}"
+puts "Response body: #{response.body}"
+```
+
+## Good
+
+```
+require 'faraday'
+
+# Create a Faraday connection
+conn = Faraday.new(url: 'https://jsonplaceholder.typicode.com')
+
+# Make a GET request
+response = conn.get('/posts/1')
+
+# Print response information
+puts "Response code: #{response.status}"
+puts "Response body: #{response.body}"
+```
 

--- a/_patterns/prefer_faraday_as_http_client.md
+++ b/_patterns/prefer_faraday_as_http_client.md
@@ -29,7 +29,7 @@ External gem for retrying requests with httparty
 
 ## Good
 
-```
+```ruby
 require 'faraday'
 # GET request
 Faraday.get('https://jsonplaceholder.typicode.com/posts/1')

--- a/_patterns/prefer_faraday_as_http_client.md
+++ b/_patterns/prefer_faraday_as_http_client.md
@@ -37,11 +37,11 @@ Faraday.get('https://jsonplaceholder.typicode.com/posts/1')
 require 'faraday/retry'
 conn = Faraday.new do |f|
   f.request :retry, {
-    max: 2,
+    max: 5,
     interval: 0.05,
     interval_randomness: 0.5,
     backoff_factor: 2,
-    timeout: 2,
+    timeout: 5,
   }
 end
 conn.get('https://jsonplaceholder.typicode.com/posts/1')

--- a/_patterns/prefer_faraday_as_http_client.md
+++ b/_patterns/prefer_faraday_as_http_client.md
@@ -23,16 +23,16 @@ require 'extended_httparty'
 response = HTTParty.get('https://jsonplaceholder.typicode.com/posts/1', timeout: 5)
 # GET request with retry
 response = ExtendedHttparty.get('https://jsonplaceholder.typicode.com/posts/1', tries: 5)
-
-External gem for retrying requests with httparty
 ```
 
 ## Good
 
 ```ruby
 require 'faraday'
+
 # GET request
 Faraday.get('https://jsonplaceholder.typicode.com/posts/1')
+
 # GET request with retry
 require 'faraday/retry'
 conn = Faraday.new do |f|
@@ -44,5 +44,6 @@ conn = Faraday.new do |f|
     timeout: 5,
   }
 end
+
 conn.get('https://jsonplaceholder.typicode.com/posts/1')
 ```


### PR DESCRIPTION
Although less fun, when using an http client in the app, use Faraday when possible. 