### PR TITLE
Don't force removal of the commas

### DIFF
--- a/ruby/.rubocop.yml
+++ b/ruby/.rubocop.yml
@@ -281,3 +281,9 @@ Style/WhileUntilModifier:
   Enabled: false
 Style/WordArray:
   EnforcedStyle: brackets
+Style/TrailingCommaInArrayLiteral:
+  EnforcedStyleForMultiline: false
+Style/TrailingCommaInArguments:
+  EnforcedStyleForMultiline: false
+Style/TrailingCommaInHashLiteral:
+  EnforcedStyleForMultiline: false


### PR DESCRIPTION
We removed the trailing comma rule here:https://github.com/BiggerPockets/patterns/pull/188

Removing it completely applies the rule to remove the comma in existing code.
