### PR TITLE
Don't force removal of the commas - fix the rule

### DIFF
--- a/ruby/.rubocop.yml
+++ b/ruby/.rubocop.yml
@@ -282,8 +282,8 @@ Style/WhileUntilModifier:
 Style/WordArray:
   EnforcedStyle: brackets
 Style/TrailingCommaInArrayLiteral:
-  EnforcedStyleForMultiline: false
+  Enabled: false
 Style/TrailingCommaInArguments:
-  EnforcedStyleForMultiline: false
+  Enabled: false
 Style/TrailingCommaInHashLiteral:
-  EnforcedStyleForMultiline: false
+  Enabled: false


### PR DESCRIPTION
Fix the TrailingComma rules.
When disabling a rubocop rule add `Enabled: false`.

